### PR TITLE
readme: improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Previously known as Unlimited Adventures Forever / UAForever (UAF).
 * https://sourceforge.net/projects/uaf/ - Project homepage and news
 * https://forums.goldbox.games/index.php - Forum
 * https://gitter.im/uaf-gitter/community - Chat room
+* https://grannypron.github.io/uaf/ - GitHub Pages documentation (deploy action is set up, but this is not fully working yet)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
-# uaf
+# Dungeon Craft
 
-[![Join the chat at https://gitter.im/uaf-gitter/community](https://badges.gitter.im/uaf-gitter/community.svg)](https://gitter.im/uaf-gitter/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Updated emulator of Forgotten Realms: Unlimited Adventures (FRUA), a computer game released in 1993.
+
+This is the official code repository of Dungeon Craft, a Windows desktop application written in C++. It is based off the Gold Box game engine and Gold Box dungeon design tools such as Unlimited Adventures, but has been improved. For example, many of the hard-coded limits have been increased, and higher resolution graphics assets are supported.
+
+Previously known as Unlimited Adventures Forever / UAForever (UAF).
+
+## Folders
+
+* UAFWin - Latest compiled game binary for Windows
+* UAFWinEd - Latest compiled dungeon editor binary for Windows
+* WebGLBuild - I see WebGL and the Unity game engine in this folder. A compiled website for playing the game in browser perhaps?
+* src - Source code
+
+## Links
+
+* https://uaf.sourceforge.net/ - Former official code repository. Nowadays has a link to this repo at the top.
+* https://sourceforge.net/projects/uaf/ - Project homepage and news
+* https://forums.goldbox.games/index.php - Forum
+* https://gitter.im/uaf-gitter/community - Chat room software

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Previously known as Unlimited Adventures Forever / UAForever (UAF).
 * https://uaf.sourceforge.net/ - Former official code repository. Nowadays has a link to this repo at the top.
 * https://sourceforge.net/projects/uaf/ - Project homepage and news
 * https://forums.goldbox.games/index.php - Forum
-* https://gitter.im/uaf-gitter/community - Chat room software
+* https://gitter.im/uaf-gitter/community - Chat room


### PR DESCRIPTION
Why
- I watched this repo on GitHub, then got a notification about it months later, but it took me awhile to figure out what this repo was because it's named "uaf" (cryptic acronym) and had no readme or GitHub description.

What
- Update readme to include basic details about this repo.